### PR TITLE
included bin in package.json:files

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "watch-test": "chokidar **/*.js -c \"npm run test\""
   },
   "files": [
-    "index.js"
+    "index.js",
+    "bin/"
   ],
   "keywords": [],
   "dependencies": {


### PR DESCRIPTION
I missed the cli files in package.json[files], so npm install will no longer work.
