### PR TITLE
Added support for inlining html files where developers use extra indentations and new lines between a custom component's attributes.

### DIFF
--- a/samples/custom-components-formatted.html
+++ b/samples/custom-components-formatted.html
@@ -1,0 +1,19 @@
+<!-- HTML comments like this one should be removed when compression mode is on -->
+
+<div class="navbar-collapse collapse" collapse="isCollapsed">
+	<ul class="nav sidebar-nav">
+		<!-- Extra spaces for testing compression -->
+		<cutom-list-item (onSecondClick)="secondClick()"
+                         [displayValue]="'Home'">
+        </cutom-list-item>
+        <cutom-list-item (onSecondClick)="secondClick()"
+                         [displayValue]="'About'">
+        </cutom-list-item>
+        <cutom-list-item (onSecondClick)="secondClick()" 
+                         (onComplete)="onTaskComplete()" 
+                         [displayValue]="'Contact'">
+        </cutom-list-item>
+	</ul>
+</div>
+
+<h1 *ngIf="hello">Hello World</h1>

--- a/test.js
+++ b/test.js
@@ -27,7 +27,7 @@ test('inline basic', async t => {
 
 	@Component({
 		selector: 'foo',
-		template: '<!-- HTML comments like this one should be removed when compression mode is on --><div class="navbar-collapse collapse" collapse="isCollapsed"><ul class="nav sidebar-nav"><!-- Extra spaces for testing compression --><li>  <a   href="/#/home">Home Page</a></li><li>  <a   href="/#/about">About</a></li><li>  <a   href="/#/contact">Contact</a></li></ul></div><h1>Hello World</h1>',
+		template: '<!-- HTML comments like this one should be removed when compression mode is on --><div class="navbar-collapse collapse" collapse="isCollapsed"><ul class="nav sidebar-nav"><!-- Extra spaces for testing compression --><li><a href="/#/home">Home Page</a></li><li><a href="/#/about">About</a></li><li><a href="/#/contact">Contact</a></li></ul></div><h1>Hello World</h1>',
 		styles: ['h1 {  color: #ff0000;}h1:after {  content: \\'\\';}']
 	})
 	export class ComponentX {
@@ -274,6 +274,55 @@ test('inline with relative path', async t => {
 
 	let path = require('path');
 	fn(content, options, path.join(__dirname, 'samples')).then((r) => t.is(r, result));
+});
+
+test('when components have custom events and input properties and they are written with indentation', async t => {
+
+	var content = `import {Component} from 'angular2/core';
+
+	@Component({
+		selector: 'foo',
+		templateUrl: 'custom-components-formatted.html',
+		styleUrls: ['component.css']
+	})
+	export class ComponentX {
+		constructor() {}
+	}
+
+	@Component({
+		selector: 'foo',
+		styleUrls: [
+			'component.css'
+		]
+	})
+	export class ComponentY {
+		constructor() {}
+	}`;
+
+	var result = `import {Component} from 'angular2/core';
+
+	@Component({
+		selector: 'foo',
+		template: '<!-- HTML comments like this one should be removed when compression mode is on --><div class="navbar-collapse collapse" collapse="isCollapsed"><ul class="nav sidebar-nav"><!-- Extra spaces for testing compression --><cutom-list-item (onSecondClick)="secondClick()" [displayValue]="\\'Home\\'"></cutom-list-item><cutom-list-item (onSecondClick)="secondClick()" [displayValue]="\\'About\\'"></cutom-list-item><cutom-list-item (onSecondClick)="secondClick()" (onComplete)="onTaskComplete()" [displayValue]="\\'Contact\\'"></cutom-list-item></ul></div><h1 *ngIf="hello">Hello World</h1>',
+		styles: ['h1 {  color: #ff0000;}h1:after {  content: \\'\\';}']
+	})
+	export class ComponentX {
+		constructor() {}
+	}
+
+	@Component({
+		selector: 'foo',
+		styles: ['h1 {  color: #ff0000;}h1:after {  content: \\'\\';}']
+	})
+	export class ComponentY {
+		constructor() {}
+	}`;
+
+	let options = {
+		base: 'samples'
+	};
+
+	fn(content, options).then((r) => t.is(r, result));
 });
 
 test('upper', t => {


### PR DESCRIPTION
- For example: 
```html
<custom-component 
                   (onSecClick)="sec()" 
                   (onFirClick)="fir()">
</custom-component>
```
- In this case previously the content would be inlined like this:
```html
<custom-component (onSecClick)=\"sec()\"(onFirClick)=\"fir()\"></custom-component>
```

- This sometimes breaks the inlined component when browser tries to render it.