### PR TITLE
Allow write output back to source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ Resolve `templateUrl` and `styleUrls` in Angular2 components.
 $ npm install --save angular2-inline-template-style
 ```
 
+## Build from source
+
+Just clone the repository and run:
+
+```
+npm install 
+
+npm link
+```
+
+Linking requires administration rights, e.g. sudo on Mac.
+After the package has been linked, you should be able to call ng2-inline from command line.
+
+
 ## Usage
 
 ```css
@@ -76,13 +90,14 @@ Use [html-min](https://github.com/kangax/html-minifier) and [clean-css](https://
 ## CLI
 ### Usage
 ```bash
-ng2-inline [--outDir|-o] [--base|-b] [--flatten|-f] [--up|-u <count>] [--compress|-c] [--watch|-w] <path glob>
+ng2-inline [--outDir|-o] [--base|-b] [--flatten|-f] [--up|-u <count>] [--compress|-c] [--watch|-w] [--sourceOverwrite|-s] <path glob>
 ```
 - --flatten: remove parent directories from source locations (all output is written to --outDir)
 - --up <count>: remove `count` leading folders from the source locations when writing to --outDir
 - --base: as above
 - --compress: as above
 - --watch: runs [chokidar](https://github.com/paulmillr/chokidar) on the glob and on change runs a single file inline
+- --sourceOverwrite: allows overwriting input .js files with the respective output file. This only works in case --outDir is not set.
 
 ### Examples
 ```bash

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -20,10 +20,11 @@
 			b: 'base',
 			c: 'compress',
 			w: 'watch',
-			r: 'relative'
+			r: 'relative',
+			s: 'sourceOverwrite'
 		},
 		string: ['outDir', 'base'],
-		boolean: ['flatten', 'compress', 'watch', 'relative'],
+		boolean: ['flatten', 'compress', 'watch', 'relative', 'sourceOverwrite'],
 		number: ['up']
 	});
 
@@ -64,7 +65,18 @@
 								file = upper(file, args.up);
 							}
 
-							var destination = path.join(args.outDir, file);
+							let out = args.outDir;
+
+							if (typeof args.outDir === 'undefined') {
+								if (typeof args.sourceOverwrite === 'undefined') {
+									console.log('No out path set. If you want to replace input files, set -s switch');
+								} else {
+									out = path.dirname(target);
+								}
+							}
+
+							var destination = path.join(out, file);
+							console.log('Wrting ' + destination);
 							if (!fs.existsSync(path.dirname(destination))) {
 								mkdirp(path.dirname(destination));
 							}


### PR DESCRIPTION
- Introduced new command line switch --sourceOverwrite. It allows writing back output to source file, but only in case --outDir is empty.
- Documented changes in README.md
- Also documented steps for building from source
- Tests run fine
- Lint runs fine