### PR TITLE
fix multiline attributes causing `Unterminated string`

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,9 @@ function processTemplateUrl(content, options, targetDir) {
 			// escape quote chars
 			file = file.replace(new RegExp(quote, 'g'), '\\' + quote);
 
+			// join multilines
+			file = file.split('\n').join(quote + ' +\n' + quote);
+
 			closure = closure.replace(template, 'template: ' + quote + file + quote);
 		}
 	});

--- a/samples/multiline-attributes.html
+++ b/samples/multiline-attributes.html
@@ -1,0 +1,5 @@
+<div [ngClass]="{
+	compact: isCompact,
+	hidden: isHidden,
+	expanded: isExpanded
+}"> Test </div>

--- a/test.js
+++ b/test.js
@@ -326,7 +326,7 @@ test('when components have custom events and input properties and they are writt
 });
 
 test('when components have commented out templateUrls and styleUrls, those urls should be ignored', async t => {
-	
+
 	var content = `import {Component} from 'angular2/core';
 
 	@Component({
@@ -366,6 +366,38 @@ test('when components have commented out templateUrls and styleUrls, those urls 
 		styles: ['h1 {  color: #ff0000;}h1:after {  content: \\'\\';}']
 	})
 	export class ComponentY {
+		constructor() {}
+	}`;
+
+	let options = {
+		base: 'samples'
+	};
+
+	fn(content, options).then((r) => t.is(r, result));
+});
+
+test('when components have attributes and they are multiline', async t => {
+	var content = `import {Component} from 'angular2/core';
+
+	@Component({
+		templateUrl: 'multiline-attributes.html',
+		styleUrls: []
+	})
+	export class ComponentX {
+		constructor() {}
+	}`;
+
+	var result = `import {Component} from 'angular2/core';
+
+	@Component({
+		template: '<div [ngClass]="{' +
+'	compact: isCompact,' +
+'	hidden: isHidden,' +
+'	expanded: isExpanded' +
+'}">Test</div>',
+		styleUrls: []
+	})
+	export class ComponentX {
 		constructor() {}
 	}`;
 


### PR DESCRIPTION
If the template has multiline attributes, which is quite common use case when using `[ngClass]`, e.g.:

```html
<div [ngClass]="{
  compact: isCompact,
  hidden: isHidden,
  expanded: isExpanded
}"> Test </div>
```
resulting `js` file is broken because of `Unterminated string literal`:

```js
...
template: '<div [ngClass]="{
  compact: isCompact,
  hidden: isHidden,
  expanded: isExpanded
}">Test</div>'
...
```

I fixed that by adding concatenating code to such places, so now the result looks like:

```js
...
template: '<div [ngClass]="{' +
'  compact: isCompact,' +
'  hidden: isHidden,' +
'  expanded: isExpanded' +
'}">Test</div>',
...
```