### PR TITLE
escape \ in css

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,6 +71,9 @@ function processStyleUrls(content, options, targetDir) {
 					processed = processed.replace(/[\r\n]/g, '');
 				}
 
+				// escape \ char
+				processed = processed.replace(new RegExp('\\\\', 'g'), '\\\\');
+
 				// escape quote chars
 				processed = processed.replace(new RegExp('\'', 'g'), '\\\'');
 				return processed;

--- a/samples/component-with-icon.css
+++ b/samples/component-with-icon.css
@@ -1,0 +1,7 @@
+h1 {
+  color: #ff0000;
+}
+
+h1:after {
+  content: '\f1d8';
+}

--- a/test.js
+++ b/test.js
@@ -49,6 +49,37 @@ test('inline basic', async t => {
 	fn(content, options).then((r) => t.is(r, result));
 });
 
+test('inline content icon', async t => {
+	var content = `import {Component} from 'angular2/core';
+
+	@Component({
+		selector: 'foo',
+		styleUrls: [
+			'component-with-icon.css'
+		]
+	})
+	export class ComponentY {
+		constructor() {}
+	}`;
+
+	var result = `import {Component} from 'angular2/core';
+
+	@Component({
+		selector: 'foo',
+		styles: ['h1 {  color: #ff0000;}h1:after {  content: \\'\\\\f1d8\\';}']
+	})
+	export class ComponentY {
+		constructor() {}
+	}`;
+
+	let options = {
+		base: 'samples'
+	};
+
+	fn(content, options).then((r) => t.is(r, result));
+});
+
+
 test('inline basic less', async t => {
 	var content = `import {Component} from 'angular2/core';
 
@@ -145,6 +176,38 @@ test('inline with compress', async t => {
 
 	fn(content, options).then((r) => t.is(r, result));
 });
+
+test('inline content icon with compress', async t => {
+	var content = `import {Component} from 'angular2/core';
+
+	@Component({
+		selector: 'foo',
+		styleUrls: [
+			'component-with-icon.css'
+		]
+	})
+	export class ComponentY {
+		constructor() {}
+	}`;
+
+	var result = `import {Component} from 'angular2/core';
+
+	@Component({
+		selector: 'foo',
+		styles: ['h1{color:red}h1:after{content:\\'\\\\f1d8\\'}']
+	})
+	export class ComponentY {
+		constructor() {}
+	}`;
+
+	let options = {
+		base: 'samples',
+		compress: true
+	};
+
+	fn(content, options).then((r) => t.is(r, result));
+});
+
 
 test('inline with compress and angular2 syntax', async t => {
 	var content = `import {Component} from 'angular2/core';


### PR DESCRIPTION
fix issue when css like
```css
h1:after {
  content: '\f1d8';
}
```

it not convert `\` to `\\`. so when use in javascript it become 
```css
h1:after {
  content: '1d8';
}
```

i think this issue is exist in inline style too. but i don't have idea to fix that situation. may be use JSON.stringify but it use double quote as a wrapper 